### PR TITLE
#25: time as variable

### DIFF
--- a/examples/time/time.ino
+++ b/examples/time/time.ino
@@ -8,7 +8,7 @@
 using namespace ds;
 
 void printTime() {
-  System::log->printf("Current time (seconds since epoch): %lu\n", System::getTime());
+  System::log->printf("Current time (seconds since epoch): %lu\n", System::time);
   System::log->print("Current time (string): ");
   System::log->println(System::getTimeStr());
   System::log->print("Time sync status: ");

--- a/examples/time_change/MySystem.h
+++ b/examples/time_change/MySystem.h
@@ -1,0 +1,10 @@
+#ifndef _DS_SYSTEM_H_
+
+#define DS_CAP_SYS_LOG_HW   // Enable syslog on hardware serial line
+#define DS_CAP_SYS_TIME     // Enable system time
+
+#define DS_TIMEZONE TZ_Europe_Paris       // My timezone
+
+#include "System.h"         // System global definitions
+
+#endif // _DS_SYSTEM_H_

--- a/examples/time_change/time_change.ino
+++ b/examples/time_change/time_change.ino
@@ -1,0 +1,32 @@
+// Time monitoring example
+// Board: NodeMCU 1.0(ESP-12E Module)
+// (!) Before compiling, copy System.h and System.cpp into the sketch folder, then reopen the sketch in Arduino
+
+#include "MySystem.h"
+
+using namespace ds;
+
+void setup() {
+  System::begin();
+  System::setTime(1000000000);                        // Some date around 2001
+  delay(100);                                         // Allow new time to propagate
+}
+
+void loop() {
+  if(System::newSecond())
+    System::log->printf("%s > New second has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_sec);
+  if(System::newMinute())
+    System::log->printf("%s >> New minute has arrived: %d\n",    System::getTimeStr().c_str(), System::tm_time.tm_min);
+  if(System::newHour())
+    System::log->printf("%s >>> New hour has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_hour);
+  if(System::newDay())
+    System::log->printf("%s >>>> New day has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_mday);
+  if(System::newWeek())
+    System::log->printf("%s >>>>> New week has arrived: %d\n",   System::getTimeStr().c_str(), System::tm_time.tm_yday / 7 + 1);
+  if(System::newMonth())
+    System::log->printf("%s >>>>>> New month has arrived: %d\n", System::getTimeStr().c_str(), System::tm_time.tm_mon + 1);
+  if(System::newSecond())
+    System::log->printf("%s >>>>>>> Happy New Year %d!\n",       System::getTimeStr().c_str(), System::tm_time.tm_year + 1900);
+
+  System::update();
+}

--- a/examples/time_change/time_change.ino
+++ b/examples/time_change/time_change.ino
@@ -14,19 +14,22 @@ void setup() {
 
 void loop() {
   if(System::newSecond())
-    System::log->printf("%s > New second has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_sec);
-  if(System::newMinute())
-    System::log->printf("%s >> New minute has arrived: %d\n",    System::getTimeStr().c_str(), System::tm_time.tm_min);
-  if(System::newHour())
-    System::log->printf("%s >>> New hour has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_hour);
-  if(System::newDay())
-    System::log->printf("%s >>>> New day has arrived: %d\n",     System::getTimeStr().c_str(), System::tm_time.tm_mday);
-  if(System::newWeek())
-    System::log->printf("%s >>>>> New week has arrived: %d\n",   System::getTimeStr().c_str(), System::tm_time.tm_yday / 7 + 1);
-  if(System::newMonth())
-    System::log->printf("%s >>>>>> New month has arrived: %d\n", System::getTimeStr().c_str(), System::tm_time.tm_mon + 1);
+    System::log->println(System::getTimeStr());
+
   if(System::newSecond())
-    System::log->printf("%s >>>>>>> Happy New Year %d!\n",       System::getTimeStr().c_str(), System::tm_time.tm_year + 1900);
+    System::log->printf("New second has arrived: %02d\n", System::tm_time.tm_sec);
+  if(System::newMinute())
+    System::log->printf("New minute has arrived: %02d\n", System::tm_time.tm_min);
+  if(System::newHour())
+    System::log->printf("New hour has arrived: %02d\n",   System::tm_time.tm_hour);
+  if(System::newDay())
+    System::log->printf("New day has arrived: %02d\n",    System::tm_time.tm_mday);
+  if(System::newWeek())
+    System::log->printf("New week has arrived: %02d\n",   System::tm_time.tm_yday / 7 + 1);
+  if(System::newMonth())
+    System::log->printf("New month has arrived: %02d\n",  System::tm_time.tm_mon + 1);
+  if(System::newYear())
+    System::log->printf("Happy New Year %d!\n",           System::tm_time.tm_year + 1900);
 
   System::update();
 }

--- a/examples/timers_abs/timers_abs.ino
+++ b/examples/timers_abs/timers_abs.ino
@@ -23,22 +23,15 @@ void myTimerHandler(const TimerAbsolute* timer) {
 }
 void (*System::timerHandler)(const TimerAbsolute*) = myTimerHandler;  // Install the handler
 
-time_t old_time, new_time;
-
-void set_clock(const time_t _new_time) {
-  new_time = _new_time;
-  old_time = new_time;
-  System::setTime(new_time);
-  delay(100);                                         // Allow new time to propagate
-}
-
 void setup() {
   System::begin();
 
   // Set system time to some date around 2001
-  set_clock(1000000000);
+  System::setTime(1000000000);
+  delay(100);                                         // Allow new time to propagate
 
   // Set up two timers one minute apart
+  auto new_time = System::time;
   for (uint8_t n = 1; n <= 2; n++) {
     new_time += 60;
     struct tm *tinfo = localtime(&new_time);
@@ -54,11 +47,8 @@ void setup() {
 void loop() {
 
   // Just display current time periodically to see when the timer fires
-  new_time = System::getTime();
-  if (new_time != old_time) {
-    old_time = new_time;
+  if (System::newSecond())
     System::log->println(System::getTimeStr());
-  }
 
   System::update();
 }

--- a/examples/timers_count_abs/timers_count_abs.ino
+++ b/examples/timers_count_abs/timers_count_abs.ino
@@ -23,20 +23,12 @@ void myTimerHandler(const TimerAbsolute* timer) {
 }
 void (*System::timerHandler)(const TimerAbsolute*) = myTimerHandler;  // Install the handler
 
-time_t old_time, new_time;
-
-void set_clock(const time_t _new_time) {
-  new_time = _new_time;
-  old_time = new_time;
-  System::setTime(new_time);
-  delay(100);                                         // Allow new time to propagate
-}
-
 void setup() {
   System::begin();
 
   // Set system time to some date around 2001
-  set_clock(1000000000);
+  System::setTime(1000000000);
+  delay(100);                                         // Allow new time to propagate
 
   // Set up a countdown timer with 10 seconds period
   // Illustrates static allocation
@@ -58,11 +50,8 @@ void setup() {
 void loop() {
 
   // Just display current time periodically to see when the timers fire. Lamp should toggle every 5 seconds
-  new_time = System::getTime();
-  if (new_time != old_time) {
-    old_time = new_time;
+  if (System::newSecond())
     System::log->println(System::getTimeStr());
-  }
 
   System::update();
 }

--- a/examples/timers_solar/timers_solar.ino
+++ b/examples/timers_solar/timers_solar.ino
@@ -23,21 +23,12 @@ void myTimerHandler(const TimerAbsolute* timer) {
 }
 void (*System::timerHandler)(const TimerAbsolute*) = myTimerHandler;  // Install the handler
 
-time_t old_time, new_time;
-int counter = 0;
-
-void set_clock(const time_t _new_time) {
-  new_time = _new_time;
-  old_time = new_time;
-  System::setTime(new_time);
-  delay(100);                                         // Allow new time to propagate  
-}
-
 void setup() {
   System::begin();
 
   // Set system time to some value close to sunset
-  set_clock(1000059410);                              // Some date around 2001
+  System::setTime(1000059410);                        // Some date around 2001
+  delay(100);                                         // Allow new time to propagate
 
   // Illustrate solar events calculation
   auto sunrise = System::getSunrise();
@@ -53,16 +44,18 @@ void setup() {
   System::log->println("Timer 2 set at sunrise + 5 mins");
 }
 
+int counter = 0;
+
 void loop() {
 
   // Just display current time periodically to see when the timer fires
-  new_time = System::getTime();
-  if (new_time != old_time) {
-    old_time = new_time;
+  if (System::newSecond()) {
     System::log->println(System::getTimeStr());
 
-    if (counter++ == 15)              // After 15 sec, adjust clock to sunrise
-      set_clock(1000099430);          
+    if (counter++ == 15) {             // After 15 sec, adjust clock to sunrise
+      System::setTime(1000059410);     // Some date around 2001
+      delay(100);                      // Allow new time to propagate
+    }
   }
 
   System::update();

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -2031,12 +2031,12 @@ void System::begin() {
     cfg_file.close();
     timers.reverse();
 #ifdef DS_CAP_SYS_LOG
-  log->print(std::distance(timers.begin(), timers.end()));
-  log->println(F(" found"));
+    log->print(std::distance(timers.begin(), timers.end()));
+    log->println(F(" found"));
 #endif // DS_CAP_SYS_LOG
   } else {
 #ifdef DS_CAP_SYS_LOG
-  log->println(F("none found"));
+    log->println(F("none found"));
 #endif // DS_CAP_SYS_LOG
   }
 #endif // DS_CAP_WEB_TIMERS
@@ -2246,19 +2246,13 @@ void System::update() {
 #endif // DS_CAP_SYS_TIME
 
 #ifdef DS_CAP_TIMERS_ABS
-  static time_t old_time = 0;                  // Last second value
-  const auto new_time = getTime();
-  if (new_time != old_time) {   // Happens once a second
-    old_time = new_time;
-    struct tm tm_local;
-    localtime_r(&new_time, &tm_local);
-
+  if (newSecond()) {
 #ifdef DS_CAP_TIMERS_SOLAR
     static time_t time_solar_sync = 0;           // Last time the solar events have been calculated
 
     // Recalculate solar times every morning at 3:30 am, or at least every 24 hours
-    if ((tm_local.tm_hour == 3 && tm_local.tm_min == 30 && tm_local.tm_sec == 0) || new_time - time_solar_sync > 24 * 60 * 60) {
-      time_solar_sync = new_time;
+    if ((tm_time.tm_hour == 3 && tm_time.tm_min == 30 && tm_time.tm_sec == 0) || time - time_solar_sync > 24 * 60 * 60) {
+      time_solar_sync = time;
 #ifdef DS_CAP_SYS_LOG
       log->printf(TIMED("Recalculating solar events...\n"));
 #endif // DS_CAP_SYS_LOG
@@ -2271,7 +2265,7 @@ void System::update() {
     // Process timers
     if (abs_timers_active && time_sync_status != TIME_SYNC_NONE)
       for (auto timer : timers) {
-        if (timer && timer->getType() != TIMER_INVALID && timer->isArmed() && *timer == tm_local) {
+        if (timer && timer->getType() != TIMER_INVALID && timer->isArmed() && *timer == tm_time) {
 #ifdef DS_CAP_SYS_LOG
           log->printf(TIMED("Timer \"%s\" fired\n"), timer->getAction().c_str());
 #endif // DS_CAP_SYS_LOG
@@ -2286,7 +2280,7 @@ void System::update() {
         }
 #ifdef DS_CAP_TIMERS_COUNT_ABS
         if (timer->getType() == TIMER_COUNTDOWN_ABS) {
-          static_cast<TimerCountdownAbs *>(timer)->update(old_time);
+          static_cast<TimerCountdownAbs *>(timer)->update(time);
         }
 #endif // DS_CAP_TIMERS_COUNT_ABS
       }

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -241,7 +241,9 @@ time_t System::getTime() {
 void System::setTime(const time_t new_time) {
   const struct timeval tv_new_time = {new_time, 0};
   if (!settimeofday(&tv_new_time, NULL)) {
-    setTimeSyncTime(new_time);
+    time = new_time;
+    localtime_r(&time, &tm_time);
+    setTimeSyncTime(time);
     setTimeSyncStatus(TIME_SYNC_OK);
   }
 }

--- a/src/System.h
+++ b/src/System.h
@@ -136,6 +136,15 @@ namespace ds {
     TIME_SYNC_OK,                                     // Time is synchronized
     TIME_SYNC_DEGRADED                                // Time was synchronized but not anymore
   } time_sync_t;
+
+#define TIME_CHANGE_SECOND                        1
+#define TIME_CHANGE_MINUTE (TIME_CHANGE_SECOND << 1)
+#define TIME_CHANGE_HOUR   (TIME_CHANGE_MINUTE << 1)
+#define TIME_CHANGE_DAY    (TIME_CHANGE_HOUR   << 1)
+#define TIME_CHANGE_WEEK   (TIME_CHANGE_DAY    << 1)
+#define TIME_CHANGE_MONTH  (TIME_CHANGE_WEEK   << 1)
+#define TIME_CHANGE_YEAR   (TIME_CHANGE_MONTH  << 1)
+#define TIME_CHANGE_NONE   (TIME_CHANGE_SECOND >> 1)
 #endif // DS_CAP_SYS_TIME
 
 #ifdef DS_CAP_TIMERS
@@ -352,9 +361,13 @@ namespace ds {
     protected:
       static time_sync_t time_sync_status;            // Time synchronization status
       static time_t time_sync_time;                   // Last time the time was synchronized
+      static uint8_t time_change_flags;               // Time change flags
       static void timeSyncHandler();                  // Time sync event handler
 
     public:
+      static time_t time;                             // Current time (Unix)
+      static struct tm tm_time;                       // Current time as structure
+
       static time_t getTimeSyncTime();                // Return last time sync time
       static void setTimeSyncTime(const time_t /* new_time */); // Set last time sync time
       static time_sync_t getTimeSyncStatus();         // Return time sync status
@@ -364,6 +377,13 @@ namespace ds {
       static String getTimeStr();                     // Return current time string
       static String getTimeStr(const time_t /* t */); // Return time string for a given time
       static void (*onTimeSync)();                    // Hook to be called when time gets synchronized
+      static bool newSecond();                        // Return true if new second has arrived
+      static bool newMinute();                        // Return true if new minute has arrived
+      static bool newHour();                          // Return true if new hour has arrived
+      static bool newDay();                           // Return true if new day has arrived
+      static bool newWeek();                          // Return true if new week has arrived
+      static bool newMonth();                         // Return true if new month has arrived
+      static bool newYear();                          // Return true if new year has arrived
 #endif // DS_CAP_SYS_TIME
 
 #ifdef DS_CAP_SYS_UPTIME


### PR DESCRIPTION
This pull request resolves #25 as follows.

New calls added:

      bool System::newSecond();                        // Return true if new second has arrived
      bool System::newMinute();                        // Return true if new minute has arrived
      bool System::newHour();                          // Return true if new hour has arrived
      bool System::newDay();                           // Return true if new day has arrived
      bool System::newWeek();                          // Return true if new week has arrived
      bool System::newMonth();                         // Return true if new month has arrived
      bool System::newYear();                          // Return true if new year has arrived

Current time is now available via public fields:

      time_t System::time;                             // Current time (Unix)
      struct System::tm tm_time;                       // Current time as structure

`System::getTime()` call no longer requests time from OS but returns cached value of `System::time`. The value is updated inside `System::update()`.

New example `time_change` illustrates new functionality.